### PR TITLE
CLOSES #12: Corrected environment variable name.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,7 +53,7 @@ Vagrant.configure("2") do |config|
           SSH_SUDO: containers["ssh_sudo"],
           SSH_USER: containers["ssh_username"],
           SSH_USER_PASSWORD: containers["ssh_password"],
-          SSH_USER_HOME_DIR: "/home/%s" % containers["ssh_username"]
+          SSH_USER_HOME: "/home/%s" % containers["ssh_username"]
         }
       end
 


### PR DESCRIPTION
Resolves: #12 

Since `centos-6-1.5.0` and `centos-7-2.0.0` the environment variable `SSH_USER_HOME_DIR` has been replaced by `SSH_USER_HOME`.
